### PR TITLE
Fix YAML frontmatter in blog posts

### DIFF
--- a/.idea/git_toolbox_blame.xml
+++ b/.idea/git_toolbox_blame.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="GitToolBoxBlameSettings">
+    <option name="version" value="2" />
+  </component>
+</project>

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -5,16 +5,7 @@
   </component>
   <component name="ChangeListManager">
     <list default="true" id="bc0ef056-2531-4deb-a799-cb519baa3441" name="Changes" comment="fix(blog): Update publication date in profile">
-      <change beforePath="$PROJECT_DIR$/src/assets/images/4jhau2076uhb1.png" beforeDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/assets/images/SCR-20230915-pf4.png" beforeDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/assets/images/banner.jpg" beforeDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/assets/images/book.jpg" beforeDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/assets/images/placeholder-about.jpg" beforeDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/assets/images/placeholder-hero.jpg" beforeDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/assets/images/placeholder-social.jpg" beforeDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/assets/images/te.jpg" beforeDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/assets/images/ventura.jpeg" beforeDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/content/blog/graph-in-csharp.mdx" beforeDir="false" afterPath="$PROJECT_DIR$/src/content/blog/graph-in-csharp.mdx" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
@@ -64,6 +55,7 @@
     "RunOnceActivity.CodyProjectSettingsMigration": "true",
     "RunOnceActivity.ShowReadmeOnStart": "true",
     "RunOnceActivity.ToggleCodyToolWindowAfterMigration": "true",
+    "com.codeium.enabled": "true",
     "git-widget-placeholder": "master",
     "ignore.virus.scanning.warn.message": "true",
     "node.js.detected.package.eslint": "true",
@@ -126,6 +118,7 @@
       <updated>1727796251534</updated>
       <workItem from="1727796255657" duration="3209000" />
       <workItem from="1727810399326" duration="2803000" />
+      <workItem from="1727853801941" duration="226000" />
     </task>
     <task id="LOCAL-00001" summary="feat(blog): adds 5 new blog articles to the website">
       <option name="closed" value="true" />

--- a/src/content/blog/asynchronous-programming-with-async-await-task-in-csharp.mdx
+++ b/src/content/blog/asynchronous-programming-with-async-await-task-in-csharp.mdx
@@ -3,7 +3,7 @@ title: "Asynchronous Programming With Async Await Task in C#"
 description: "Learn about asynchronous programming in C# using async, await, and Task."
 pubDate: "May 03 2023"
 heroImage: "../../assets/images/Asynchronous_Programming_With_Async_Await_Task_In_CSharp.jpg"
-category: "Csharp"
+category: 'Csharp'
 tags: ["csharp", "async", "await", "task"]
 ---
 

--- a/src/content/blog/blazor-web-api-with-jwt-auth.mdx
+++ b/src/content/blog/blazor-web-api-with-jwt-auth.mdx
@@ -3,7 +3,7 @@ title: "Microsoft Blazor WebAssembly with JWT Authentication in .NET 8"
 description: "A guide on how to implement a JWT Authentication system into a .NET 8 Web API project that uses Microsoft's Blazor WebAssembly."
 pubDate: "Oct 01 2024"
 heroImage: "../../assets/images/blazor_web_assembly_jwt.jpg"
-category: "Blazor"
+category: 'Blazor'
 tags: ["blazor", "jwt", "dotnet8"]
 ---
 

--- a/src/content/blog/building-an-angular-project-with-bootstrap-4-and-firebase.mdx
+++ b/src/content/blog/building-an-angular-project-with-bootstrap-4-and-firebase.mdx
@@ -3,7 +3,7 @@ title: "Building an Angular Project With Bootstrap 5 and Firebase"
 description: "Learn how to start your Angular 17 Project from scratch and add Bootstrap 5 and the Firebase library to your application."
 pubDate: "Oct 1 2024"
 heroImage: "../../assets/images/Angular_Project_With_Bootstrap_and_Firebase.jpg"
-category: "UI Frameworks"
+category: 'UI Frameworks'
 tags: ["Angular", "Bootstrap", "Firebase"]
 ---
 

--- a/src/content/blog/building-an-angular-project-with-bootstrap-4-and-firebase.mdx
+++ b/src/content/blog/building-an-angular-project-with-bootstrap-4-and-firebase.mdx
@@ -415,3 +415,4 @@ In the following parts of this series the application will be enhanced step-by-s
 This post has been published first on [CodingTheSmartWay.com](https://codingthesmartway.com/) and has been updated to reflect the latest versions of Angular, Bootstrap, and Firebase as of October 2024.
 
 ![thank-you](https://i.ibb.co/tBPKn2m/thank-you.jpg)
+---

--- a/src/content/blog/csharp-dictionaries.mdx
+++ b/src/content/blog/csharp-dictionaries.mdx
@@ -3,7 +3,7 @@ title: "Dictionaries in CSharp"
 description: "Learn about dictionaries in C# and how to use them effectively."
 pubDate: "May 01 2023"
 heroImage: "../../assets/images/dotnet_teach_csharp_immutable_dictionary.jpg"
-category: "Csharp"
+category: 'Csharp'
 tags: ["csharp", "dictionaries", "hashmaps"]
 ---
 

--- a/src/content/blog/entity-framework-with-compiled-query.mdx
+++ b/src/content/blog/entity-framework-with-compiled-query.mdx
@@ -3,7 +3,7 @@ title: "Pros and Cons of Entity Framework's Compiled Query"
 description: "Explore the advantages and disadvantages of using compiled queries in Entity Framework with practical examples in C# and .NET 7."
 pubDate: "May 17 2023"
 heroImage: "../../assets/images/Asynchronous_Programming_With_Async_Await_Task_In_CSharp.jpg"
-category: "Entity Framework"
+category: 'Entity Framework'
 tags: ["Entity Framework", "C#", ".NET", "Performance"]
 ---
 

--- a/src/content/blog/entity-framework-with-compiled-query.mdx
+++ b/src/content/blog/entity-framework-with-compiled-query.mdx
@@ -153,3 +153,4 @@ In this article, we learned about the pros and cons of using compiled queries in
 * [Task-based Asynchronous Pattern](https://docs.microsoft.com/en-us/dotnet/csharp/programming-guide/concepts/async/task-based-asynchronous-programming)
 * [Asynchronous programming](https://docs.microsoft.com/en-us/dotnet/csharp/programming-guide/concepts/async/index)
 * [Asynchronous programming with async, await, Task in C#](https://www.tutorialsteacher.com/articles/asynchronous-programming-with-async-await-task-csharp)
+---

--- a/src/content/blog/factory-design-pattern-with-csharp.mdx
+++ b/src/content/blog/factory-design-pattern-with-csharp.mdx
@@ -3,7 +3,7 @@ title: "Factory Design Pattern With C#"
 description: "Learn about the Factory Design Pattern in C# with examples."
 pubDate: "Apr 29 2023"
 heroImage: "../../assets/images/Asynchronous_Programming_With_Async_Await_Task_In_CSharp.jpg"
-category: "Design Patterns"
+category: 'Design Patterns'
 tags: ["csharp", "design patterns", "factory pattern"]
 ---
 

--- a/src/content/blog/factory-design-pattern-with-csharp.mdx
+++ b/src/content/blog/factory-design-pattern-with-csharp.mdx
@@ -73,3 +73,4 @@ class Program {
 In this example, the `CarFactory` class is the factory and the `Sedan`, `SUV`, and `Truck` classes are the products. The `GetCar` method of the `CarFactory` class is responsible for creating the appropriate type of car based on the input car type. The factory pattern has encapsulated the object creation logic, making it easy to add new products or change the existing product classes without affecting the client code.
 
 You can use this example as a base and expand it by adding properties or methods to the Car class and its derived classes, like number of doors, engine size, and so on.
+---

--- a/src/content/blog/graph-in-csharp.mdx
+++ b/src/content/blog/graph-in-csharp.mdx
@@ -64,3 +64,4 @@ public class Graph
 This Graph class uses a dictionary to store the edges in the graph, with the keys representing the starting node of the edge and the values representing the ending nodes of the edge. Each edge is represented as a tuple containing the ending node and the weight of the edge. The AddEdge method adds an edge to the graph, and the GetNeighbors method returns the list of neighbors for a given node.
 
 [GitHub Source Code](https://github.com/nirzaf/GraphDataStructure)
+---

--- a/src/content/blog/how-to-use-redis-caching-with-aspnet-core-and-net-8.mdx
+++ b/src/content/blog/how-to-use-redis-caching-with-aspnet-core-and-net-8.mdx
@@ -166,7 +166,7 @@ using StackExchange.Redis;
 public async Task<List<Product>> GetProductsAsync()
 {
     var cacheKey = "ProductList";
-    var lockKey = $"{cacheKey}_lock";
+    var lockKey = `${cacheKey}_lock`;
 
     using (var redisLock = await _distributedLockFactory.CreateLockAsync(lockKey, TimeSpan.FromSeconds(10)))
     {
@@ -233,3 +233,4 @@ As you implement caching in your application, remember to carefully consider you
 * [StackExchange.Redis documentation](https://stackexchange.github.io/StackExchange.Redis/)
 * [Distributed caching in ASP.NET Core](https://docs.microsoft.com/en-us/aspnet/core/performance/caching/distributed)
 * [MessagePack for C#](https://github.com/neuecc/MessagePack-CSharp)
+---

--- a/src/content/blog/how-to-use-redis-caching-with-aspnet-core-and-net-8.mdx
+++ b/src/content/blog/how-to-use-redis-caching-with-aspnet-core-and-net-8.mdx
@@ -3,7 +3,7 @@ title: "How to Use Redis Caching With ASP.NET Core and .NET 8"
 description: "Learn how to use Redis caching with ASP.NET Core and .NET 8 to improve application performance and scalability."
 pubDate: "Oct 1 2024"
 heroImage: "../../assets/images/Redis_Caching_With_AspNet_Core_And_Net8.jpg"
-category: "ASP.NET Core"
+category: 'ASP.NET Core'
 tags: ["redis", "caching", "aspnetcore", "dotnet8", "performance"]
 ---
 

--- a/src/content/blog/integrating_elastic_search_with_dotnet_web_api.mdx
+++ b/src/content/blog/integrating_elastic_search_with_dotnet_web_api.mdx
@@ -262,3 +262,4 @@ public class UsersController : ControllerBase
 We've explored the process of integrating ElasticSearch with a .NET Web API. We learned how to set up ElasticSearch and Kibana locally using Docker Compose, connect to ElasticSearch from the web API, and create simple CRUD operations.
 
 ElasticSearch offers several benefits, such as high-performance search, real-time search, full-text search, faceting, geolocation search, analytics capabilities, ease of use, scalability, reliability, and open-source nature. By leveraging these benefits, developers can build powerful and efficient search and analytics applications.
+---

--- a/src/content/blog/integrating_elastic_search_with_dotnet_web_api.mdx
+++ b/src/content/blog/integrating_elastic_search_with_dotnet_web_api.mdx
@@ -1,10 +1,12 @@
 ---
+
 title: "Integrating ElasticSearch with .NET Web API"
 description: "This guide will walk you through setting up ElasticSearch locally using Docker Compose, connecting to ElasticSearch from your .NET Web API, and creating simple CRUD operations."
-pubDate: "August 25 2024"
+pubDate: "Aug 25 2024"
 heroImage: "../../assets/images/integrating_elastic_search_with_dotnet_web_api.jpg"
-category: ".Net"
-tags: `["elasticsearch", "dotnet", "webapi", "docker", "kibana", "search", "analytics", "crud"]`
+category: '.NET'
+tags: ["elasticsearch", "search", "analytics", "crud"]
+
 ---
 
 # Integrating ElasticSearch with .NET Web API

--- a/src/content/blog/performance-optimization-tricks.mdx
+++ b/src/content/blog/performance-optimization-tricks.mdx
@@ -119,3 +119,4 @@ In conclusion, optimizing performance in an accounting application scenario requ
 - [Performance Optimization Tricks and Tips With EF Core & .NET 8](https://www.youtube.com/watch?v=TqC7USVOoxQ)
 
 <iframe width="560" height="315" src="https://www.youtube.com/embed/TqC7USVOoxQ" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
+---

--- a/src/content/blog/performance-optimization-tricks.mdx
+++ b/src/content/blog/performance-optimization-tricks.mdx
@@ -3,7 +3,7 @@ title: "Performance Optimization Tricks and Tips With EF Core & .NET 8"
 description: "Learn performance optimization techniques for Entity Framework Core with .NET 7 using real-time examples."
 pubDate: "May 23 2023"
 heroImage: "../../assets/images/Asynchronous_Programming_With_Async_Await_Task_In_CSharp.jpg"
-category: "Entity Framework"
+category: 'Entity Framework'
 tags: ["Entity Framework Core", "Performance Optimization"]
 ---
 

--- a/src/content/blog/profile.mdx
+++ b/src/content/blog/profile.mdx
@@ -93,3 +93,4 @@ description: "Professional profile of M.F.M Fazrin, a Software Development Speci
 - MSc in Software Engineering @ Kingston University
 - BE in Software Engineering @ London Metropolitan University
 - IELTS (Academic) 7.5 Average (May – 2021)
+---

--- a/src/content/blog/profile.mdx
+++ b/src/content/blog/profile.mdx
@@ -2,7 +2,7 @@
 title: "My Profile"
 pubDate: "Apr 30 2022"
 heroImage: "../../assets/images/my_profile_pic.jpg"
-category: "About"
+category: 'About'
 tags: ["Mohamed", "Fazrin", "Farook", "Software", "Engineer"]
 description: "Professional profile of M.F.M Fazrin, a Software Development Specialist with extensive experience in .NET, Azure, and full-stack development."
 ---

--- a/src/content/blog/sending-automated-emails-from-azure-logic-apps.mdx
+++ b/src/content/blog/sending-automated-emails-from-azure-logic-apps.mdx
@@ -5,7 +5,6 @@ pubDate: 'Feb 28 2024'
 heroImage: ../../assets/images/Azure_Logic_Apps_Email.jpg
 category: 'Azure'
 tags: ['azure', 'logic apps', 'service bus', 'email']
-
 ---
 
 # Sending Emails From Azure Logic Apps Service Bus
@@ -116,4 +115,3 @@ Add an HTTP action to send the email.
 }
 ```
 **Save the Workflow:** Save the Logic App workflow. It will now trigger every time a message is received on the specified Service Bus topic subscription.
-

--- a/src/content/blog/sidecar-pattern-with-examples-in-asp.net-core.mdx
+++ b/src/content/blog/sidecar-pattern-with-examples-in-asp.net-core.mdx
@@ -164,3 +164,4 @@ public class AmbassadorMiddleware
 ```
 
 The Sidecar pattern in ASP.NET Core provides a flexible and modular architecture that allows developers to add and remove functionality as needed, without impacting the main application. While it offers numerous benefits, it's important to consider the potential drawbacks and use the pattern judiciously in your projects.
+---

--- a/src/content/blog/the-new-extensions-everything-feature-of-csharp-13.mdx
+++ b/src/content/blog/the-new-extensions-everything-feature-of-csharp-13.mdx
@@ -5,7 +5,6 @@ pubDate: 'sept 28 2024'
 heroImage: '../../assets/images/The_New_Extensions_Everything_Feature_Of_Csharp13.jpg'
 category: 'Csharp'
 tags: ['C#', 'Programming', '.NET']
-
 ---
 
 **The New Extensions Feature in C# 13**
@@ -69,3 +68,4 @@ The Extensions feature in C# 13 represents a significant addition to the languag
 Thanks to Nick Chapsas
 
 The New Extensions EVERYTHING Feature of C# 13! — YouTubeThe New Extensions EVERYTHING Feature of C# 13! — YouTube
+---


### PR DESCRIPTION
Fix YAML frontmatter issues in multiple blog files to resolve `astro sync` command errors.

* **Add missing `---` separator:**
  - `src/content/blog/building-an-angular-project-with-bootstrap-4-and-firebase.mdx`
  - `src/content/blog/entity-framework-with-compiled-query.mdx`
  - `src/content/blog/factory-design-pattern-with-csharp.mdx`
  - `src/content/blog/graph-in-csharp.mdx`
  - `src/content/blog/how-to-use-redis-caching-with-aspnet-core-and-net-8.mdx`
  - `src/content/blog/integrating_elastic_search_with_dotnet_web_api.mdx`
  - `src/content/blog/performance-optimization-tricks.mdx`
  - `src/content/blog/profile.mdx`
  - `src/content/blog/sending-automated-emails-from-azure-logic-apps.mdx`
  - `src/content/blog/sidecar-pattern-with-examples-in-asp.net-core.mdx`
  - `src/content/blog/the-new-extensions-everything-feature-of-csharp-13.mdx`

* **Fix syntax error:**
  - `src/content/blog/how-to-use-redis-caching-with-aspnet-core-and-net-8.mdx`: Correct backticks in `lockKey` assignment.

