### PR TITLE
Fix search modal to refresh page before opening

### DIFF
--- a/src/components/Search.astro
+++ b/src/components/Search.astro
@@ -6,7 +6,7 @@ import SearchIcon from '@/components/icons/SearchIcon'
 ---
 
 <site-search id='search' class='ms-auto'>
-	<button data-open-modal disabled class='flex items-center justify-center rounded-md gap-1'>
+	<button data-open-modal class='flex items-center justify-center rounded-md gap-1'>
 		<SearchIcon />
 		<!-- <span class='md:hidden text-2xl'> Search</span> -->
 	</button>
@@ -63,6 +63,7 @@ import SearchIcon from '@/components/icons/SearchIcon'
 				} else return
 			}
 			const openModal = (event?: MouseEvent) => {
+				location.reload()
 				dialog.showModal()
 
 				animate(


### PR DESCRIPTION
Enable the search button and refresh the page before opening the search modal.

* **Enable Search Button**
  - Remove the `disabled` attribute from the search button in `src/components/Search.astro`.

* **Refresh Page Before Opening Modal**
  - Modify the `openModal` function to refresh the page before opening the search modal in `src/components/Search.astro`.

