### PR TITLE
Add page refresh after navigation

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -37,5 +37,17 @@ const { title, description, image, articleDate } = Astro.props
 				margin-left: calc(100vw - 100%); /* prevent layout shift */
 			}
 		</style>
+		<script>
+			window.addEventListener('beforeunload', function () {
+				sessionStorage.setItem('refreshPage', 'true');
+			});
+
+			window.addEventListener('load', function () {
+				if (sessionStorage.getItem('refreshPage') === 'true') {
+					sessionStorage.removeItem('refreshPage');
+					location.reload();
+				}
+			});
+		</script>
 	</body>
 </html>


### PR DESCRIPTION
Add a script to refresh the page once automatically after navigating to a new page.

* **Script Addition**
  - Add a script to `src/layouts/BaseLayout.astro` to handle page refresh after navigation.
  - Use `beforeunload` event to set a flag in `sessionStorage`.
  - Check the flag on page load and refresh if set.
  - Clear the flag after refreshing to prevent infinite loops.

